### PR TITLE
feat: add Ollama local model support

### DIFF
--- a/apps/backend/src/modules/ai-connector/clients/ai-ollama-proxy.ts
+++ b/apps/backend/src/modules/ai-connector/clients/ai-ollama-proxy.ts
@@ -1,0 +1,26 @@
+import type { SdkAIModelT } from '@dashhub/sdk';
+import type { SearchEnginesService } from '~/modules/search-engines';
+
+import { AIOpenAIProxy } from './ai-openai-proxy';
+
+const OLLAMA_DEFAULT_URL = 'http://localhost:11434/v1';
+
+export class AIollamaProxy extends AIOpenAIProxy {
+  constructor(
+    aiModel: SdkAIModelT,
+    searchEnginesService: SearchEnginesService,
+  ) {
+    super(
+      {
+        ...aiModel,
+        credentials: {
+          ...aiModel.credentials,
+          apiUrl: aiModel.credentials.apiUrl || OLLAMA_DEFAULT_URL,
+          // Ollama's OpenAI-compatible API accepts any non-empty key
+          apiKey: aiModel.credentials.apiKey || 'ollama',
+        },
+      },
+      searchEnginesService,
+    );
+  }
+}

--- a/apps/backend/src/modules/ai-connector/clients/get-ai-proxy-for-model.ts
+++ b/apps/backend/src/modules/ai-connector/clients/get-ai-proxy-for-model.ts
@@ -5,6 +5,7 @@ import type { AIProxy } from './ai-proxy';
 
 import { AIDeepSeekModel } from './ai-deepseek-proxy';
 import { AIGeminiProxy } from './ai-gemini-proxy';
+import { AIollamaProxy } from './ai-ollama-proxy';
 import { AIOpenAIProxy } from './ai-openai-proxy';
 
 export function getAIModelProxyForModel(searchEnginesService: SearchEnginesService) {
@@ -12,6 +13,9 @@ export function getAIModelProxyForModel(searchEnginesService: SearchEnginesServi
     switch (aiModel.provider) {
       case 'deepseek':
         return new AIDeepSeekModel(aiModel, searchEnginesService);
+
+      case 'ollama':
+        return new AIollamaProxy(aiModel, searchEnginesService);
 
       case 'other':
       case 'openai':

--- a/apps/backend/src/modules/ai-connector/clients/index.ts
+++ b/apps/backend/src/modules/ai-connector/clients/index.ts
@@ -1,4 +1,5 @@
 export * from './ai-gemini-proxy';
+export * from './ai-ollama-proxy';
 export * from './ai-openai-proxy';
 export * from './ai-proxy';
 export * from './get-ai-proxy-for-model';

--- a/apps/chat/src/i18n/packs/i18n-lang-en.ts
+++ b/apps/chat/src/i18n/packs/i18n-lang-en.ts
@@ -24,6 +24,7 @@ const I18N_AI_PROVIDERS_EN: Record<SdkAIProviderT, string> = {
   openai: 'OpenAI',
   gemini: 'Gemini',
   deepseek: 'DeepSeek',
+  ollama: 'Ollama (Local)',
   other: 'Other',
 };
 

--- a/apps/chat/src/i18n/packs/i18n-lang-pl.ts
+++ b/apps/chat/src/i18n/packs/i18n-lang-pl.ts
@@ -26,7 +26,8 @@ const I18N_AI_PROVIDERS_PL: Record<SdkAIProviderT, string> = {
   openai: 'OpenAI',
   gemini: 'Gemini',
   deepseek: 'DeepSeek',
-  other: 'Other',
+  ollama: 'Ollama (Lokalnie)',
+  other: 'Inne',
 };
 
 const I18N_SEARCH_ENGINE_PROVIDERS_PL: Record<SdkSearchEngineProviderT, string> = {

--- a/apps/chat/src/modules/ai-models/form/shared/ai-model-credentials-form-field.tsx
+++ b/apps/chat/src/modules/ai-models/form/shared/ai-model-credentials-form-field.tsx
@@ -12,35 +12,39 @@ type Props = ValidationErrorsListProps<SdkAICredentialsT> & {
 export const AIModelCredentialsFormFields = controlled<SdkAICredentialsT, Props>(({ errors, provider, control: { bind } }) => {
   const t = useI18n().pack.aiModels.form.fields.credentials;
   const validation = useFormValidatorMessages({ errors });
+  const isOllama = provider === 'ollama';
+  const showApiUrl = provider === 'other' || isOllama;
 
   return (
     <>
-      {provider === 'other' && (
+      {showApiUrl && (
         <FormField
           className="uk-margin"
           label={t.apiUrl.label}
           {...validation.extract('apiUrl')}
         >
           <Input
-            name="name"
-            placeholder={t.apiUrl.placeholder}
+            name="apiUrl"
+            placeholder={isOllama ? 'http://localhost:11434/v1' : t.apiUrl.placeholder}
             {...bind.path('apiUrl')}
           />
         </FormField>
       )}
 
-      <FormField
-        className="uk-margin"
-        label={t.apiKey.label}
-        {...validation.extract('apiKey')}
-      >
-        <Input
-          name="name"
-          placeholder={t.apiKey.placeholder}
-          required
-          {...bind.path('apiKey')}
-        />
-      </FormField>
+      {!isOllama && (
+        <FormField
+          className="uk-margin"
+          label={t.apiKey.label}
+          {...validation.extract('apiKey')}
+        >
+          <Input
+            name="apiKey"
+            placeholder={t.apiKey.placeholder}
+            required
+            {...bind.path('apiKey')}
+          />
+        </FormField>
+      )}
 
       <FormField
         className="uk-margin"
@@ -48,8 +52,8 @@ export const AIModelCredentialsFormFields = controlled<SdkAICredentialsT, Props>
         {...validation.extract('apiModel')}
       >
         <Input
-          name="name"
-          placeholder={t.apiModel.placeholder}
+          name="apiModel"
+          placeholder={isOllama ? 'llama3.2' : t.apiModel.placeholder}
           required
           {...bind.path('apiModel')}
         />

--- a/packages/sdk/src/modules/dashboard/ai-models/dto/credentials/openai-credentials.dto.ts
+++ b/packages/sdk/src/modules/dashboard/ai-models/dto/credentials/openai-credentials.dto.ts
@@ -2,6 +2,6 @@ import { z } from 'zod';
 
 export const SdkOpenAICredentialsV = z.object({
   apiUrl: z.string().optional(),
-  apiKey: z.string(),
+  apiKey: z.string().optional().default(''),
   apiModel: z.string(),
 });

--- a/packages/sdk/src/modules/dashboard/ai-models/dto/sdk-ai-model.dto.ts
+++ b/packages/sdk/src/modules/dashboard/ai-models/dto/sdk-ai-model.dto.ts
@@ -14,6 +14,7 @@ export const SDK_AI_PROVIDERS = [
   'openai',
   'gemini',
   'deepseek',
+  'ollama',
   'other',
 ] as const;
 


### PR DESCRIPTION
## Summary

Adds [Ollama](https://ollama.com/) as an AI provider so teams can run local models (Llama 3, Mistral, Phi, etc.) without sending data to external APIs.

- New `ollama` provider in the AI model provider enum
- `AIollamaProxy` class extends `AIOpenAIProxy` — Ollama speaks OpenAI-compatible API
- Defaults to `http://localhost:11434/v1`; `apiKey` is not required (Ollama ignores it)
- UI hides the API key field for Ollama and shows `llama3.2` as the model placeholder
- EN + PL translations: `Ollama (Local)` / `Ollama (Lokalnie)`

## How to use

1. Install Ollama: https://ollama.com/download
2. Pull a model: `ollama pull llama3.2`
3. In DashHub admin → AI Models → add model with provider `Ollama`
4. URL defaults to `http://localhost:11434/v1`, enter model name (e.g. `llama3.2`)

## Test plan

- [ ] Create an Ollama AI model in admin settings
- [ ] Start a chat using the Ollama model
- [ ] Verify responses come from the local model
- [ ] Verify OpenAI models still work unchanged
- [ ] Verify `apiKey` field is hidden in the Ollama credentials form

🤖 Generated with [Claude Code](https://claude.com/claude-code)