### PR TITLE
feat: add eval/benchmark runner for AI model testing

### DIFF
--- a/apps/backend/src/migrations/0053-add-eval-tables.ts
+++ b/apps/backend/src/migrations/0053-add-eval-tables.ts
@@ -62,6 +62,7 @@ export async function up(db: Kysely<any>) {
       col.notNull().references('eval_cases.id').onDelete('cascade'))
     .addColumn('ai_response', 'text')
     .addColumn('latency_ms', 'integer')
+    .addColumn('passed', 'boolean')
     .addColumn('error_message', 'text')
     .execute();
 
@@ -69,6 +70,12 @@ export async function up(db: Kysely<any>) {
     .createIndex('eval_results_run_id_idx')
     .on('eval_results')
     .column('run_id')
+    .execute();
+
+  await db.schema
+    .createIndex('eval_results_case_id_idx')
+    .on('eval_results')
+    .column('case_id')
     .execute();
 }
 

--- a/apps/backend/src/migrations/0053-add-eval-tables.ts
+++ b/apps/backend/src/migrations/0053-add-eval-tables.ts
@@ -1,0 +1,80 @@
+import type { Kysely } from 'kysely';
+
+import { addIdColumn, addTimestampColumns } from './utils';
+
+export async function up(db: Kysely<any>) {
+  await db.schema
+    .createTable('eval_suites')
+    .$call(addIdColumn)
+    .$call(addTimestampColumns)
+    .addColumn('organization_id', 'integer', col =>
+      col.notNull().references('organizations.id').onDelete('cascade'))
+    .addColumn('name', 'varchar', col => col.notNull())
+    .addColumn('description', 'text')
+    .execute();
+
+  await db.schema
+    .createIndex('eval_suites_organization_id_idx')
+    .on('eval_suites')
+    .column('organization_id')
+    .execute();
+
+  await db.schema
+    .createTable('eval_cases')
+    .$call(addIdColumn)
+    .$call(addTimestampColumns)
+    .addColumn('suite_id', 'integer', col =>
+      col.notNull().references('eval_suites.id').onDelete('cascade'))
+    .addColumn('input_message', 'text', col => col.notNull())
+    .addColumn('expected_note', 'text')
+    .execute();
+
+  await db.schema
+    .createIndex('eval_cases_suite_id_idx')
+    .on('eval_cases')
+    .column('suite_id')
+    .execute();
+
+  await db.schema
+    .createTable('eval_runs')
+    .$call(addIdColumn)
+    .$call(addTimestampColumns)
+    .addColumn('suite_id', 'integer', col =>
+      col.notNull().references('eval_suites.id').onDelete('cascade'))
+    .addColumn('ai_model_id', 'integer', col =>
+      col.notNull().references('ai_models.id').onDelete('cascade'))
+    .addColumn('status', 'varchar', col => col.notNull().defaultTo('pending'))
+    .execute();
+
+  await db.schema
+    .createIndex('eval_runs_suite_id_idx')
+    .on('eval_runs')
+    .column('suite_id')
+    .execute();
+
+  await db.schema
+    .createTable('eval_results')
+    .$call(addIdColumn)
+    .$call(addTimestampColumns)
+    .addColumn('run_id', 'integer', col =>
+      col.notNull().references('eval_runs.id').onDelete('cascade'))
+    .addColumn('case_id', 'integer', col =>
+      col.notNull().references('eval_cases.id').onDelete('cascade'))
+    .addColumn('ai_response', 'text')
+    .addColumn('latency_ms', 'integer')
+    .addColumn('error_message', 'text')
+    .execute();
+
+  await db.schema
+    .createIndex('eval_results_run_id_idx')
+    .on('eval_results')
+    .column('run_id')
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema.dropTable('eval_results').execute();
+  await db.schema.dropTable('eval_runs').execute();
+  await db.schema.dropTable('eval_cases').execute();
+  await db.schema.dropTable('eval_suites').execute();
+}

--- a/apps/backend/src/migrations/index.ts
+++ b/apps/backend/src/migrations/index.ts
@@ -51,6 +51,7 @@ import * as addExternalAPIsTable from './0049-add-external-apis-table';
 import * as addExternalAPIToApps from './0050-add-external-api-to-apps';
 import * as dropMaxNumberOfUsersFromOrganizations from './0051-drop-max-number-of-users-from-organization';
 import * as addMCPServersTable from './0052-add-mcp-servers-table';
+import * as addEvalTables from './0053-add-eval-tables';
 
 export const DB_MIGRATIONS = {
   '0000-add-users-tables': addUsersTables,
@@ -106,4 +107,5 @@ export const DB_MIGRATIONS = {
   '0050-add-external-api-to-apps': addExternalAPIToApps,
   '0051-drop-max-number-of-users-from-organization': dropMaxNumberOfUsersFromOrganizations,
   '0052-add-mcp-servers-table': addMCPServersTable,
+  '0053-add-eval-tables': addEvalTables,
 };

--- a/apps/backend/src/modules/api/controllers/dashboard/dashboard.controller.ts
+++ b/apps/backend/src/modules/api/controllers/dashboard/dashboard.controller.ts
@@ -6,6 +6,7 @@ import { AIModelsController } from './ai-models.controller';
 import { AppsCategoriesController } from './apps-categories.controller';
 import { AppsController } from './apps.controller';
 import { ChatsController } from './chats.controller';
+import { EvalsController } from './evals.controller';
 import { FavoritesController } from './favorites.controller';
 import { OrganizationsController } from './organizations.controller';
 import { PinnedMessagesController } from './pinned-messages.controller';
@@ -35,6 +36,7 @@ export class DashboardController extends BaseController {
     @inject(PinnedMessagesController) pinnedMessages: PinnedMessagesController,
     @inject(FavoritesController) favorites: FavoritesController,
     @inject(AIExternalAPIsController) aiExternalAPIs: AIExternalAPIsController,
+    @inject(EvalsController) evals: EvalsController,
   ) {
     super();
 
@@ -53,6 +55,7 @@ export class DashboardController extends BaseController {
       .route('/search-engines', searchEngines.router)
       .route('/share-resource', shareResource.router)
       .route('/pinned-messages', pinnedMessages.router)
-      .route('/favorites', favorites.router);
+      .route('/favorites', favorites.router)
+      .route('/evals', evals.router);
   }
 }

--- a/apps/backend/src/modules/api/controllers/dashboard/evals.controller.ts
+++ b/apps/backend/src/modules/api/controllers/dashboard/evals.controller.ts
@@ -1,0 +1,102 @@
+import { pipe } from 'fp-ts/lib/function';
+import { inject, injectable } from 'tsyringe';
+
+import {
+  type EvalsSdk,
+  SdkCreateEvalCaseInputV,
+  SdkCreateEvalRunInputV,
+  SdkCreateEvalSuiteInputV,
+} from '@dashhub/sdk';
+import { ConfigService } from '~/modules/config';
+import { EvalsService } from '~/modules/evals';
+
+import {
+  mapDbRecordNotFoundToSdkError,
+  rejectUnsafeSdkErrors,
+  sdkSchemaValidator,
+  serializeSdkResponseTE,
+} from '../../helpers';
+import { AuthorizedController } from '../shared/authorized.controller';
+
+@injectable()
+export class EvalsController extends AuthorizedController {
+  constructor(
+    @inject(ConfigService) configService: ConfigService,
+    @inject(EvalsService) evalsService: EvalsService,
+  ) {
+    super(configService);
+
+    this.router
+      .post(
+        '/suites',
+        sdkSchemaValidator('json', SdkCreateEvalSuiteInputV),
+        async context => pipe(
+          context.req.valid('json'),
+          evalsService.asUser(context.var.jwt).createSuite,
+          rejectUnsafeSdkErrors,
+          serializeSdkResponseTE<ReturnType<EvalsSdk['createSuite']>>(context),
+        ),
+      )
+      .get(
+        '/suites/by-org/:organizationId',
+        async context => pipe(
+          Number(context.req.param().organizationId),
+          evalsService.asUser(context.var.jwt).listSuites,
+          rejectUnsafeSdkErrors,
+          serializeSdkResponseTE<ReturnType<EvalsSdk['listSuites']>>(context),
+        ),
+      )
+      .post(
+        '/cases',
+        sdkSchemaValidator('json', SdkCreateEvalCaseInputV),
+        async context => pipe(
+          context.req.valid('json'),
+          evalsService.asUser(context.var.jwt).createCase,
+          mapDbRecordNotFoundToSdkError,
+          rejectUnsafeSdkErrors,
+          serializeSdkResponseTE<ReturnType<EvalsSdk['createCase']>>(context),
+        ),
+      )
+      .get(
+        '/cases/by-suite/:suiteId',
+        async context => pipe(
+          Number(context.req.param().suiteId),
+          evalsService.asUser(context.var.jwt).listCases,
+          mapDbRecordNotFoundToSdkError,
+          rejectUnsafeSdkErrors,
+          serializeSdkResponseTE<ReturnType<EvalsSdk['listCases']>>(context),
+        ),
+      )
+      .post(
+        '/runs',
+        sdkSchemaValidator('json', SdkCreateEvalRunInputV),
+        async context => pipe(
+          context.req.valid('json'),
+          evalsService.asUser(context.var.jwt).createRun,
+          mapDbRecordNotFoundToSdkError,
+          rejectUnsafeSdkErrors,
+          serializeSdkResponseTE<ReturnType<EvalsSdk['createRun']>>(context),
+        ),
+      )
+      .get(
+        '/runs/by-suite/:suiteId',
+        async context => pipe(
+          Number(context.req.param().suiteId),
+          evalsService.asUser(context.var.jwt).listRuns,
+          mapDbRecordNotFoundToSdkError,
+          rejectUnsafeSdkErrors,
+          serializeSdkResponseTE<ReturnType<EvalsSdk['listRuns']>>(context),
+        ),
+      )
+      .get(
+        '/results/by-run/:runId',
+        async context => pipe(
+          Number(context.req.param().runId),
+          evalsService.asUser(context.var.jwt).listResults,
+          mapDbRecordNotFoundToSdkError,
+          rejectUnsafeSdkErrors,
+          serializeSdkResponseTE<ReturnType<EvalsSdk['listResults']>>(context),
+        ),
+      );
+  }
+}

--- a/apps/backend/src/modules/api/controllers/dashboard/index.ts
+++ b/apps/backend/src/modules/api/controllers/dashboard/index.ts
@@ -4,6 +4,7 @@ export * from './apps-categories.controller';
 export * from './apps.controller';
 export * from './chats.controller';
 export * from './dashboard.controller';
+export * from './evals.controller';
 export * from './favorites.controller';
 export * from './organizations.controller';
 export * from './pinned-messages.controller';

--- a/apps/backend/src/modules/database/database.tables.ts
+++ b/apps/backend/src/modules/database/database.tables.ts
@@ -14,6 +14,13 @@ import type {
   ChatsTable,
 } from '../chats';
 import type { ChatSummariesTable } from '../chats-summaries';
+import type {
+  EvalCasesTable,
+  EvalResultsTable,
+  EvalRunsTable,
+  EvalSuitesTable,
+} from '../evals';
+import type { MCPServersTable } from '../mcp-servers';
 import type { MessagesTable } from '../messages';
 import type {
   OrganizationsS3BucketsTable,
@@ -95,6 +102,15 @@ export type DatabaseTables =
 
     // External APIs
     ai_external_apis: AIExternalAPIsTable;
+
+    // MCP Servers
+    mcp_servers: MCPServersTable;
+
+    // Evals
+    eval_suites: EvalSuitesTable;
+    eval_cases: EvalCasesTable;
+    eval_runs: EvalRunsTable;
+    eval_results: EvalResultsTable;
   }
   & CommercialDatabase;
 

--- a/apps/backend/src/modules/evals/evals.firewall.ts
+++ b/apps/backend/src/modules/evals/evals.firewall.ts
@@ -1,0 +1,96 @@
+import { taskEither as TE } from 'fp-ts';
+import { pipe } from 'fp-ts/lib/function';
+
+import type {
+  SdkCreateEvalCaseInputT,
+  SdkCreateEvalRunInputT,
+  SdkCreateEvalSuiteInputT,
+  SdkJwtTokenT,
+} from '@dashhub/sdk';
+
+import { AuthFirewallService } from '~/modules/auth/firewall';
+
+import type { TableId } from '../database';
+import type { PermissionsService } from '../permissions';
+import type { EvalsService } from './evals.service';
+
+export class EvalsFirewall extends AuthFirewallService {
+  constructor(
+    jwt: SdkJwtTokenT,
+    private readonly evalsService: EvalsService,
+    private readonly permissionsService: Readonly<PermissionsService>,
+  ) {
+    super(jwt);
+  }
+
+  createSuite = (dto: SdkCreateEvalSuiteInputT) => pipe(
+    this.permissionsService.asUser(this.jwt).enforceOrganizationScope(dto),
+    TE.fromEither,
+    TE.chainW(this.evalsService.createSuite),
+    this.tryTEIfUser.oneOfOrganizationRole('owner', 'tech'),
+  );
+
+  listSuites = (organizationId: TableId) => pipe(
+    this.permissionsService.asUser(this.jwt).enforceMatchingOrganizationId(organizationId),
+    TE.fromEither,
+    TE.chainW(() => this.evalsService.listSuites(organizationId)),
+  );
+
+  createCase = (dto: SdkCreateEvalCaseInputT) => pipe(
+    this.evalsService.getSuite(dto.suiteId),
+    TE.chainW(suite =>
+      pipe(
+        this.permissionsService.asUser(this.jwt).enforceMatchingOrganizationId(suite.organization.id),
+        TE.fromEither,
+      ),
+    ),
+    TE.chainW(() => this.evalsService.createCase(dto)),
+    this.tryTEIfUser.oneOfOrganizationRole('owner', 'tech'),
+  );
+
+  listCases = (suiteId: TableId) => pipe(
+    this.evalsService.getSuite(suiteId),
+    TE.chainW(suite =>
+      pipe(
+        this.permissionsService.asUser(this.jwt).enforceMatchingOrganizationId(suite.organization.id),
+        TE.fromEither,
+      ),
+    ),
+    TE.chainW(() => this.evalsService.listCases(suiteId)),
+  );
+
+  createRun = (dto: SdkCreateEvalRunInputT) => pipe(
+    this.evalsService.getSuite(dto.suiteId),
+    TE.chainW(suite =>
+      pipe(
+        this.permissionsService.asUser(this.jwt).enforceMatchingOrganizationId(suite.organization.id),
+        TE.fromEither,
+      ),
+    ),
+    TE.chainW(() => this.evalsService.createRun(dto)),
+    this.tryTEIfUser.oneOfOrganizationRole('owner', 'tech'),
+  );
+
+  listRuns = (suiteId: TableId) => pipe(
+    this.evalsService.getSuite(suiteId),
+    TE.chainW(suite =>
+      pipe(
+        this.permissionsService.asUser(this.jwt).enforceMatchingOrganizationId(suite.organization.id),
+        TE.fromEither,
+      ),
+    ),
+    TE.chainW(() => this.evalsService.listRuns(suiteId)),
+  );
+
+  listResults = (runId: TableId) => pipe(
+    this.evalsService.getRun(runId),
+    TE.chainW(run => this.evalsService.getSuite(run.suiteId)),
+    TE.chainW(suite =>
+      pipe(
+        this.permissionsService.asUser(this.jwt).enforceMatchingOrganizationId(suite.organization.id),
+        TE.fromEither,
+      ),
+    ),
+    TE.chainW(() => this.evalsService.listResults(runId)),
+  );
+}

--- a/apps/backend/src/modules/evals/evals.firewall.ts
+++ b/apps/backend/src/modules/evals/evals.firewall.ts
@@ -67,6 +67,11 @@ export class EvalsFirewall extends AuthFirewallService {
         TE.fromEither,
       ),
     ),
+    TE.chainW(() =>
+      this.permissionsService.asUser(this.jwt).findRecordAndCheckOrganizationMatch({
+        findRecord: this.evalsService.getAiModel(dto.aiModelId),
+      }),
+    ),
     TE.chainW(() => this.evalsService.createRun(dto)),
     this.tryTEIfUser.oneOfOrganizationRole('owner', 'tech'),
   );

--- a/apps/backend/src/modules/evals/evals.repo.ts
+++ b/apps/backend/src/modules/evals/evals.repo.ts
@@ -207,6 +207,7 @@ export class EvalResultsRepo extends createProtectedDatabaseRepo('eval_results')
       caseId: TableId;
       aiResponse?: string | null;
       latencyMs?: number | null;
+      passed?: boolean | null;
       errorMessage?: string | null;
     };
   }>) => this.baseRepo.create({ forwardTransaction, value });

--- a/apps/backend/src/modules/evals/evals.repo.ts
+++ b/apps/backend/src/modules/evals/evals.repo.ts
@@ -1,0 +1,231 @@
+import camelcaseKeys from 'camelcase-keys';
+import { array as A, taskEither as TE } from 'fp-ts';
+import { pipe } from 'fp-ts/lib/function';
+import { injectable } from 'tsyringe';
+
+import {
+  createProtectedDatabaseRepo,
+  DatabaseError,
+  DatabaseRecordNotExists,
+  TableId,
+  TransactionalAttrs,
+  tryReuseTransactionOrSkip,
+} from '~/modules/database';
+
+import type {
+  EvalCaseTableRow,
+  EvalResultTableRow,
+  EvalRunStatus,
+  EvalRunTableRow,
+  EvalSuiteTableRowWithRelations,
+} from './evals.tables';
+
+@injectable()
+export class EvalSuitesRepo extends createProtectedDatabaseRepo('eval_suites') {
+  createIdsIterator = this.baseRepo.createIdsIterator;
+
+  create = ({ forwardTransaction, value: { organization, ...value } }: TransactionalAttrs<{
+    value: { organization: { id: TableId; }; name: string; description?: string | null; };
+  }>) => this.baseRepo.create({
+    forwardTransaction,
+    value: {
+      ...value,
+      organizationId: organization.id,
+    },
+  });
+
+  findByOrganizationId = ({ forwardTransaction, organizationId }: TransactionalAttrs<{ organizationId: TableId; }>) => {
+    const transaction = tryReuseTransactionOrSkip({ db: this.db, forwardTransaction });
+
+    return pipe(
+      transaction(
+        async qb =>
+          qb
+            .selectFrom(this.table)
+            .where('eval_suites.organization_id', '=', organizationId)
+            .innerJoin('organizations', 'organizations.id', 'organization_id')
+            .selectAll('eval_suites')
+            .select([
+              'organizations.id as organization_id',
+              'organizations.name as organization_name',
+            ])
+            .orderBy('eval_suites.created_at', 'desc')
+            .execute(),
+      ),
+      DatabaseError.tryTask,
+      TE.map(
+        A.map(({
+          organization_id: orgId,
+          organization_name: orgName,
+          ...item
+        }): EvalSuiteTableRowWithRelations => ({
+          ...camelcaseKeys(item),
+          organization: { id: orgId, name: orgName },
+        })),
+      ),
+    );
+  };
+
+  findById = ({ forwardTransaction, id }: TransactionalAttrs<{ id: TableId; }>) => {
+    const transaction = tryReuseTransactionOrSkip({ db: this.db, forwardTransaction });
+
+    return pipe(
+      transaction(
+        async qb =>
+          qb
+            .selectFrom(this.table)
+            .where('eval_suites.id', '=', id)
+            .innerJoin('organizations', 'organizations.id', 'organization_id')
+            .selectAll('eval_suites')
+            .select([
+              'organizations.id as organization_id',
+              'organizations.name as organization_name',
+            ])
+            .executeTakeFirst(),
+      ),
+      DatabaseError.tryTask,
+      TE.chainW((row) => {
+        if (!row) {
+          return TE.left(new DatabaseRecordNotExists({}));
+        }
+
+        const {
+          organization_id: orgId,
+          organization_name: orgName,
+          ...rest
+        } = row;
+
+        return TE.right({
+          ...camelcaseKeys(rest),
+          organization: { id: orgId, name: orgName },
+        } as EvalSuiteTableRowWithRelations);
+      }),
+    );
+  };
+}
+
+@injectable()
+export class EvalCasesRepo extends createProtectedDatabaseRepo('eval_cases') {
+  create = ({ forwardTransaction, value }: TransactionalAttrs<{
+    value: { suiteId: TableId; inputMessage: string; expectedNote?: string | null; };
+  }>) => this.baseRepo.create({ forwardTransaction, value });
+
+  findBySuiteId = ({ forwardTransaction, suiteId }: TransactionalAttrs<{ suiteId: TableId; }>) => {
+    const transaction = tryReuseTransactionOrSkip({ db: this.db, forwardTransaction });
+
+    return pipe(
+      transaction(
+        async qb =>
+          qb
+            .selectFrom(this.table)
+            .where('eval_cases.suite_id', '=', suiteId)
+            .selectAll()
+            .orderBy('eval_cases.created_at', 'asc')
+            .execute(),
+      ),
+      DatabaseError.tryTask,
+      TE.map(A.map(row => camelcaseKeys(row) as EvalCaseTableRow)),
+    );
+  };
+}
+
+@injectable()
+export class EvalRunsRepo extends createProtectedDatabaseRepo('eval_runs') {
+  create = ({ forwardTransaction, value }: TransactionalAttrs<{
+    value: { suiteId: TableId; aiModelId: TableId; };
+  }>) => this.baseRepo.create({
+    forwardTransaction,
+    value: {
+      ...value,
+      status: 'pending' as EvalRunStatus,
+    },
+  });
+
+  updateStatus = ({ forwardTransaction, id, status }: TransactionalAttrs<{ id: TableId; status: EvalRunStatus; }>) => {
+    const transaction = tryReuseTransactionOrSkip({ db: this.db, forwardTransaction });
+
+    return pipe(
+      transaction(
+        async qb =>
+          qb
+            .updateTable(this.table)
+            .set({ status })
+            .where('id', '=', id)
+            .returningAll()
+            .executeTakeFirstOrThrow(),
+      ),
+      DatabaseError.tryTask,
+      TE.map(row => camelcaseKeys(row) as EvalRunTableRow),
+    );
+  };
+
+  findById = ({ forwardTransaction, id }: TransactionalAttrs<{ id: TableId; }>) => {
+    const transaction = tryReuseTransactionOrSkip({ db: this.db, forwardTransaction });
+
+    return pipe(
+      transaction(
+        async qb =>
+          qb
+            .selectFrom(this.table)
+            .where('eval_runs.id', '=', id)
+            .selectAll()
+            .executeTakeFirst(),
+      ),
+      DatabaseError.tryTask,
+      TE.chainW(row =>
+        row
+          ? TE.right(camelcaseKeys(row) as EvalRunTableRow)
+          : TE.left(new DatabaseRecordNotExists({})),
+      ),
+    );
+  };
+
+  findBySuiteId = ({ forwardTransaction, suiteId }: TransactionalAttrs<{ suiteId: TableId; }>) => {
+    const transaction = tryReuseTransactionOrSkip({ db: this.db, forwardTransaction });
+
+    return pipe(
+      transaction(
+        async qb =>
+          qb
+            .selectFrom(this.table)
+            .where('eval_runs.suite_id', '=', suiteId)
+            .selectAll()
+            .orderBy('eval_runs.created_at', 'desc')
+            .execute(),
+      ),
+      DatabaseError.tryTask,
+      TE.map(A.map(row => camelcaseKeys(row) as EvalRunTableRow)),
+    );
+  };
+}
+
+@injectable()
+export class EvalResultsRepo extends createProtectedDatabaseRepo('eval_results') {
+  create = ({ forwardTransaction, value }: TransactionalAttrs<{
+    value: {
+      runId: TableId;
+      caseId: TableId;
+      aiResponse?: string | null;
+      latencyMs?: number | null;
+      errorMessage?: string | null;
+    };
+  }>) => this.baseRepo.create({ forwardTransaction, value });
+
+  findByRunId = ({ forwardTransaction, runId }: TransactionalAttrs<{ runId: TableId; }>) => {
+    const transaction = tryReuseTransactionOrSkip({ db: this.db, forwardTransaction });
+
+    return pipe(
+      transaction(
+        async qb =>
+          qb
+            .selectFrom(this.table)
+            .where('eval_results.run_id', '=', runId)
+            .selectAll()
+            .orderBy('eval_results.created_at', 'asc')
+            .execute(),
+      ),
+      DatabaseError.tryTask,
+      TE.map(A.map(row => camelcaseKeys(row) as EvalResultTableRow)),
+    );
+  };
+}

--- a/apps/backend/src/modules/evals/evals.service.ts
+++ b/apps/backend/src/modules/evals/evals.service.ts
@@ -1,0 +1,59 @@
+import { inject, injectable } from 'tsyringe';
+
+import type {
+  SdkCreateEvalCaseInputT,
+  SdkCreateEvalRunInputT,
+  SdkCreateEvalSuiteInputT,
+  SdkJwtTokenT,
+} from '@dashhub/sdk';
+
+import type { WithAuthFirewall } from '../auth';
+import type { TableId } from '../database';
+
+import { PermissionsService } from '../permissions';
+import { EvalsFirewall } from './evals.firewall';
+import {
+  EvalCasesRepo,
+  EvalResultsRepo,
+  EvalRunsRepo,
+  EvalSuitesRepo,
+} from './evals.repo';
+
+@injectable()
+export class EvalsService implements WithAuthFirewall<EvalsFirewall> {
+  constructor(
+    @inject(EvalSuitesRepo) private readonly suitesRepo: EvalSuitesRepo,
+    @inject(EvalCasesRepo) private readonly casesRepo: EvalCasesRepo,
+    @inject(EvalRunsRepo) private readonly runsRepo: EvalRunsRepo,
+    @inject(EvalResultsRepo) private readonly resultsRepo: EvalResultsRepo,
+    @inject(PermissionsService) private readonly permissionsService: PermissionsService,
+  ) {}
+
+  asUser = (jwt: SdkJwtTokenT) => new EvalsFirewall(jwt, this, this.permissionsService);
+
+  createSuite = (value: SdkCreateEvalSuiteInputT) =>
+    this.suitesRepo.create({ value });
+
+  listSuites = (organizationId: TableId) =>
+    this.suitesRepo.findByOrganizationId({ organizationId });
+
+  getSuite = (id: TableId) =>
+    this.suitesRepo.findById({ id });
+
+  createCase = (value: SdkCreateEvalCaseInputT) =>
+    this.casesRepo.create({ value });
+
+  listCases = (suiteId: TableId) =>
+    this.casesRepo.findBySuiteId({ suiteId });
+
+  createRun = (value: SdkCreateEvalRunInputT) =>
+    this.runsRepo.create({ value });
+
+  getRun = (id: TableId) => this.runsRepo.findById({ id });
+
+  listRuns = (suiteId: TableId) =>
+    this.runsRepo.findBySuiteId({ suiteId });
+
+  listResults = (runId: TableId) =>
+    this.resultsRepo.findByRunId({ runId });
+}

--- a/apps/backend/src/modules/evals/evals.service.ts
+++ b/apps/backend/src/modules/evals/evals.service.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'tsyringe';
+import { delay, inject, injectable } from 'tsyringe';
 
 import type {
   SdkCreateEvalCaseInputT,
@@ -10,6 +10,7 @@ import type {
 import type { WithAuthFirewall } from '../auth';
 import type { TableId } from '../database';
 
+import { AIModelsService } from '../ai-models';
 import { PermissionsService } from '../permissions';
 import { EvalsFirewall } from './evals.firewall';
 import {
@@ -26,7 +27,8 @@ export class EvalsService implements WithAuthFirewall<EvalsFirewall> {
     @inject(EvalCasesRepo) private readonly casesRepo: EvalCasesRepo,
     @inject(EvalRunsRepo) private readonly runsRepo: EvalRunsRepo,
     @inject(EvalResultsRepo) private readonly resultsRepo: EvalResultsRepo,
-    @inject(PermissionsService) private readonly permissionsService: PermissionsService,
+    @inject(delay(() => PermissionsService)) private readonly permissionsService: Readonly<PermissionsService>,
+    @inject(delay(() => AIModelsService)) private readonly aiModelsService: Readonly<AIModelsService>,
   ) {}
 
   asUser = (jwt: SdkJwtTokenT) => new EvalsFirewall(jwt, this, this.permissionsService);
@@ -39,6 +41,8 @@ export class EvalsService implements WithAuthFirewall<EvalsFirewall> {
 
   getSuite = (id: TableId) =>
     this.suitesRepo.findById({ id });
+
+  getAiModel = (id: TableId) => this.aiModelsService.get(id);
 
   createCase = (value: SdkCreateEvalCaseInputT) =>
     this.casesRepo.create({ value });

--- a/apps/backend/src/modules/evals/evals.tables.ts
+++ b/apps/backend/src/modules/evals/evals.tables.ts
@@ -1,0 +1,49 @@
+import type { ColumnType } from 'kysely';
+
+import type {
+  NormalizeSelectTableRow,
+  TableId,
+  TableRowWithIdName,
+  TableWithDefaultColumns,
+} from '../database';
+
+export type EvalSuitesTable = TableWithDefaultColumns & {
+  organization_id: ColumnType<TableId, TableId, never>;
+  name: string;
+  description: string | null;
+};
+
+export type EvalSuiteTableRow = NormalizeSelectTableRow<EvalSuitesTable>;
+
+export type EvalSuiteTableRowWithRelations = Omit<EvalSuiteTableRow, 'organizationId'> & {
+  organization: TableRowWithIdName;
+};
+
+export type EvalCasesTable = TableWithDefaultColumns & {
+  suite_id: ColumnType<TableId, TableId, never>;
+  input_message: string;
+  expected_note: string | null;
+};
+
+export type EvalCaseTableRow = NormalizeSelectTableRow<EvalCasesTable>;
+
+export const EVAL_RUN_STATUSES = ['pending', 'running', 'completed', 'failed'] as const;
+export type EvalRunStatus = typeof EVAL_RUN_STATUSES[number];
+
+export type EvalRunsTable = TableWithDefaultColumns & {
+  suite_id: ColumnType<TableId, TableId, never>;
+  ai_model_id: ColumnType<TableId, TableId, never>;
+  status: EvalRunStatus;
+};
+
+export type EvalRunTableRow = NormalizeSelectTableRow<EvalRunsTable>;
+
+export type EvalResultsTable = TableWithDefaultColumns & {
+  run_id: ColumnType<TableId, TableId, never>;
+  case_id: ColumnType<TableId, TableId, never>;
+  ai_response: string | null;
+  latency_ms: number | null;
+  error_message: string | null;
+};
+
+export type EvalResultTableRow = NormalizeSelectTableRow<EvalResultsTable>;

--- a/apps/backend/src/modules/evals/evals.tables.ts
+++ b/apps/backend/src/modules/evals/evals.tables.ts
@@ -43,6 +43,7 @@ export type EvalResultsTable = TableWithDefaultColumns & {
   case_id: ColumnType<TableId, TableId, never>;
   ai_response: string | null;
   latency_ms: number | null;
+  passed: boolean | null;
   error_message: string | null;
 };
 

--- a/apps/backend/src/modules/evals/index.ts
+++ b/apps/backend/src/modules/evals/index.ts
@@ -1,0 +1,4 @@
+export * from './evals.firewall';
+export * from './evals.repo';
+export * from './evals.service';
+export * from './evals.tables';

--- a/packages/sdk/src/modules/dashboard/dashboard.sdk.ts
+++ b/packages/sdk/src/modules/dashboard/dashboard.sdk.ts
@@ -5,6 +5,7 @@ import { AIModelsSdk } from './ai-models';
 import { AppsSdk } from './apps';
 import { AppsCategoriesSdk } from './apps-categories';
 import { ChatsSdk } from './chats';
+import { EvalsSdk } from './evals';
 import { ExpertsSdk } from './experts';
 import { FavoritesSdk } from './favorites';
 import { OrganizationsSdk } from './organizations';
@@ -52,6 +53,8 @@ export class DashboardSdk {
   public readonly pinnedMessages = new PinnedMessagesSdk(this.config);
 
   public readonly favorites = new FavoritesSdk(this.config);
+
+  public readonly evals = new EvalsSdk(this.config);
 
   constructor(private readonly config: AbstractNestedSdkWithAuthConfig) {}
 }

--- a/packages/sdk/src/modules/dashboard/evals/dto/index.ts
+++ b/packages/sdk/src/modules/dashboard/evals/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './sdk-eval-case.dto';
+export * from './sdk-eval-run.dto';
+export * from './sdk-eval-suite.dto';

--- a/packages/sdk/src/modules/dashboard/evals/dto/sdk-eval-case.dto.ts
+++ b/packages/sdk/src/modules/dashboard/evals/dto/sdk-eval-case.dto.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+import { NonEmptyOrNullStringV } from '@dashhub/commons';
+import { SdkTableRowIdV, SdkTableRowWithDatesV, SdkTableRowWithIdV } from '~/shared';
+
+export const SdkEvalCaseV = z.object({
+  suiteId: SdkTableRowIdV,
+  inputMessage: z.string().min(1),
+  expectedNote: NonEmptyOrNullStringV,
+})
+  .merge(SdkTableRowWithIdV)
+  .merge(SdkTableRowWithDatesV);
+
+export type SdkEvalCaseT = z.infer<typeof SdkEvalCaseV>;
+
+export const SdkCreateEvalCaseInputV = z.object({
+  suiteId: SdkTableRowIdV,
+  inputMessage: z.string().min(1),
+  expectedNote: NonEmptyOrNullStringV,
+});
+
+export type SdkCreateEvalCaseInputT = z.infer<typeof SdkCreateEvalCaseInputV>;
+
+export const SdkCreateEvalCaseOutputV = SdkTableRowWithIdV;
+
+export type SdkCreateEvalCaseOutputT = z.infer<typeof SdkCreateEvalCaseOutputV>;

--- a/packages/sdk/src/modules/dashboard/evals/dto/sdk-eval-run.dto.ts
+++ b/packages/sdk/src/modules/dashboard/evals/dto/sdk-eval-run.dto.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+import { SdkTableRowIdV, SdkTableRowWithDatesV, SdkTableRowWithIdV } from '~/shared';
+
+export const SDK_EVAL_RUN_STATUSES = ['pending', 'running', 'completed', 'failed'] as const;
+
+export const SdkEvalRunStatusV = z.enum(SDK_EVAL_RUN_STATUSES);
+
+export type SdkEvalRunStatusT = z.infer<typeof SdkEvalRunStatusV>;
+
+export const SdkEvalRunV = z.object({
+  suiteId: SdkTableRowIdV,
+  aiModelId: SdkTableRowIdV,
+  status: SdkEvalRunStatusV,
+})
+  .merge(SdkTableRowWithIdV)
+  .merge(SdkTableRowWithDatesV);
+
+export type SdkEvalRunT = z.infer<typeof SdkEvalRunV>;
+
+export const SdkCreateEvalRunInputV = z.object({
+  suiteId: SdkTableRowIdV,
+  aiModelId: SdkTableRowIdV,
+});
+
+export type SdkCreateEvalRunInputT = z.infer<typeof SdkCreateEvalRunInputV>;
+
+export const SdkCreateEvalRunOutputV = SdkTableRowWithIdV;
+
+export type SdkCreateEvalRunOutputT = z.infer<typeof SdkCreateEvalRunOutputV>;
+
+export const SdkEvalResultV = z.object({
+  runId: SdkTableRowIdV,
+  caseId: SdkTableRowIdV,
+  aiResponse: z.string().nullable(),
+  latencyMs: z.number().int().nullable(),
+  errorMessage: z.string().nullable(),
+})
+  .merge(SdkTableRowWithIdV)
+  .merge(SdkTableRowWithDatesV);
+
+export type SdkEvalResultT = z.infer<typeof SdkEvalResultV>;

--- a/packages/sdk/src/modules/dashboard/evals/dto/sdk-eval-run.dto.ts
+++ b/packages/sdk/src/modules/dashboard/evals/dto/sdk-eval-run.dto.ts
@@ -34,6 +34,7 @@ export const SdkEvalResultV = z.object({
   caseId: SdkTableRowIdV,
   aiResponse: z.string().nullable(),
   latencyMs: z.number().int().nullable(),
+  passed: z.boolean().nullable(),
   errorMessage: z.string().nullable(),
 })
   .merge(SdkTableRowWithIdV)

--- a/packages/sdk/src/modules/dashboard/evals/dto/sdk-eval-suite.dto.ts
+++ b/packages/sdk/src/modules/dashboard/evals/dto/sdk-eval-suite.dto.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+import { NonEmptyOrNullStringV } from '@dashhub/commons';
+import {
+  SdkTableRowWithDatesV,
+  SdkTableRowWithIdNameV,
+  SdkTableRowWithIdV,
+} from '~/shared';
+
+export const SdkEvalSuiteV = z.object({
+  organization: SdkTableRowWithIdNameV,
+  description: NonEmptyOrNullStringV,
+})
+  .merge(SdkTableRowWithIdNameV)
+  .merge(SdkTableRowWithDatesV);
+
+export type SdkEvalSuiteT = z.infer<typeof SdkEvalSuiteV>;
+
+export const SdkCreateEvalSuiteInputV = z.object({
+  name: z.string().min(1),
+  description: NonEmptyOrNullStringV,
+  organization: SdkTableRowWithIdV,
+});
+
+export type SdkCreateEvalSuiteInputT = z.infer<typeof SdkCreateEvalSuiteInputV>;
+
+export const SdkCreateEvalSuiteOutputV = SdkTableRowWithIdV;
+
+export type SdkCreateEvalSuiteOutputT = z.infer<typeof SdkCreateEvalSuiteOutputV>;

--- a/packages/sdk/src/modules/dashboard/evals/evals.sdk.ts
+++ b/packages/sdk/src/modules/dashboard/evals/evals.sdk.ts
@@ -1,0 +1,66 @@
+import { AbstractNestedSdkWithAuth } from '~/modules/abstract-nested-sdk-with-auth';
+import {
+  getPayload,
+  postPayload,
+  type SdkRecordNotFoundError,
+  type SdkTableRowIdT,
+} from '~/shared';
+
+import type {
+  SdkCreateEvalCaseInputT,
+  SdkCreateEvalCaseOutputT,
+  SdkCreateEvalRunInputT,
+  SdkCreateEvalRunOutputT,
+  SdkCreateEvalSuiteInputT,
+  SdkCreateEvalSuiteOutputT,
+  SdkEvalCaseT,
+  SdkEvalResultT,
+  SdkEvalRunT,
+  SdkEvalSuiteT,
+} from './dto';
+
+export class EvalsSdk extends AbstractNestedSdkWithAuth {
+  protected endpointPrefix = '/dashboard/evals';
+
+  createSuite = (data: SdkCreateEvalSuiteInputT) =>
+    this.fetch<SdkCreateEvalSuiteOutputT>({
+      url: this.endpoint('/suites'),
+      options: postPayload(data),
+    });
+
+  listSuites = (organizationId: SdkTableRowIdT) =>
+    this.fetch<SdkEvalSuiteT[]>({
+      url: this.endpoint(`/suites/by-org/${organizationId}`),
+      options: getPayload(),
+    });
+
+  createCase = (data: SdkCreateEvalCaseInputT) =>
+    this.fetch<SdkCreateEvalCaseOutputT>({
+      url: this.endpoint('/cases'),
+      options: postPayload(data),
+    });
+
+  listCases = (suiteId: SdkTableRowIdT) =>
+    this.fetch<SdkEvalCaseT[], SdkRecordNotFoundError>({
+      url: this.endpoint(`/cases/by-suite/${suiteId}`),
+      options: getPayload(),
+    });
+
+  createRun = (data: SdkCreateEvalRunInputT) =>
+    this.fetch<SdkCreateEvalRunOutputT, SdkRecordNotFoundError>({
+      url: this.endpoint('/runs'),
+      options: postPayload(data),
+    });
+
+  listRuns = (suiteId: SdkTableRowIdT) =>
+    this.fetch<SdkEvalRunT[], SdkRecordNotFoundError>({
+      url: this.endpoint(`/runs/by-suite/${suiteId}`),
+      options: getPayload(),
+    });
+
+  listResults = (runId: SdkTableRowIdT) =>
+    this.fetch<SdkEvalResultT[], SdkRecordNotFoundError>({
+      url: this.endpoint(`/results/by-run/${runId}`),
+      options: getPayload(),
+    });
+}

--- a/packages/sdk/src/modules/dashboard/evals/index.ts
+++ b/packages/sdk/src/modules/dashboard/evals/index.ts
@@ -1,0 +1,2 @@
+export * from './dto';
+export * from './evals.sdk';

--- a/packages/sdk/src/modules/dashboard/index.ts
+++ b/packages/sdk/src/modules/dashboard/index.ts
@@ -4,6 +4,7 @@ export * from './apps';
 export * from './apps-categories';
 export * from './chats';
 export * from './dashboard.sdk';
+export * from './evals';
 export * from './experts';
 export * from './favorites';
 export * from './mcp-servers';


### PR DESCRIPTION
## Summary

- Adds a full eval/benchmark runner backend module — the first self-hosted AI workspace to have built-in model testing
- New DB tables: `eval_suites`, `eval_cases`, `eval_runs`, `eval_results` (migration 0053)
- REST API via `/dashboard/evals/*` with full org-scope permission enforcement
- SDK client (`EvalsSdk`) for frontend consumption
- Fixes missing `mcp_servers` and all eval tables in `DatabaseTables` type registry

## Architecture

```
Suites (named test collections)
  └── Cases (input_message + expected_note)
       └── Runs (suite + AI model → status: pending/running/completed/failed)
            └── Results (ai_response + latency_ms + passed + error_message)
```

## Security

- All writes gated to `owner` or `tech` role
- `createRun` verifies both `suiteId` and `aiModelId` belong to the caller's org (cross-tenant reference prevention)
- All reads scoped to the caller's organization

## What's Next (Contributions Welcome)

- [ ] Execution engine: background job that sends `inputMessage` to the AI model and writes results
- [ ] Frontend UI for managing suites, running evals, and viewing pass/fail dashboards
- [ ] Scoring strategies beyond boolean pass/fail (cosine similarity, LLM-as-judge)

## Test plan

- [ ] `POST /dashboard/evals/suites` creates suite scoped to org
- [ ] `POST /dashboard/evals/cases` creates case under owned suite
- [ ] `POST /dashboard/evals/runs` with aiModelId from different org → 401
- [ ] `GET /dashboard/evals/suites/by-org/:id` returns only own org's suites
- [ ] `npm run db:migrate` applies migration cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)